### PR TITLE
shortened button size and gap

### DIFF
--- a/src/components/Atoms/ConfirmDialog.tsx
+++ b/src/components/Atoms/ConfirmDialog.tsx
@@ -51,7 +51,7 @@ export default function ConfirmDialog({
         onClose={onClose}
       >
         <div className="fixed inset-0 bg-gray-900/60" />
-        <div className="fixed inset-0 overflow-y-auto">
+        <div className="fixed inset-0 overflow-y-auto drop-shadow-lg">
           <div className="flex min-h-full items-center justify-center">
             <Dialog.Panel className="flex w-[500px] flex-col items-stretch justify-center gap-6 rounded-2xl border border-gray-faded/30 bg-gray-850 p-12">
               <Dialog.Title
@@ -66,7 +66,7 @@ export default function ConfirmDialog({
               >
                 {children}
               </Dialog.Description>
-              <div className="flex flex-row gap-6">
+              <div className="flex flex-row gap-2">
                 <Button
                   label={closeButtonText || 'Cancel'}
                   className={onConfirm ? 'w-fit' : 'grow'}
@@ -76,7 +76,6 @@ export default function ConfirmDialog({
                 {onConfirm && (
                   <Button
                     label={confirmButtonText || 'Confirm'}
-                    className="grow"
                     intention={type === 'danger' ? 'danger' : 'info'}
                     loading={isLoading}
                     onClick={() => {


### PR DESCRIPTION
Old modal:
![image](https://user-images.githubusercontent.com/83772958/220512829-f0f91120-a8be-4ada-b7ae-25f128c85ee6.png)

New modal:
![image](https://user-images.githubusercontent.com/83772958/220512801-1b2c945c-d8cc-4a55-a3b6-0f9f481d6528.png)

Added drop-shadow and fixed the button