### PR TITLE
#157 Unify errors into a single component

### DIFF
--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -1,0 +1,21 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
+
+interface ErrorGraphicProps {
+  iconProp: IconDefinition;
+  message: string;
+}
+
+export default function ErrorGraphic({ iconProp, message }: ErrorGraphicProps) {
+    return (
+      <div className="flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-t-lg border-b border-gray-faded/30 bg-gray-800">
+        <FontAwesomeIcon
+          icon={iconProp}
+          className="text-title text-gray-400"
+        />
+        <p className="text-center text-h3 font-medium text-white/50">
+          {message}
+        </p>
+      </div>
+    )
+}

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
-import { cn } from "utils/util";
+import clsx from "clsx";
 
 interface ErrorGraphicProps {
   icon: IconDefinition;
@@ -13,16 +13,16 @@ interface ErrorGraphicProps {
 
 export default function ErrorGraphic({ className, icon, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
     return (
-      <div className={cn('flex', 'h-full', 'w-full', 'grow', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'bg-gray-800', className)}>
+      <div className={clsx('flex', 'h-full', 'w-full', 'grow', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'bg-gray-800', className)}>
         <FontAwesomeIcon
           icon={icon}
-          className={`text-title ${iconClassName}`}
+          className={clsx('text-title', iconClassName)}
         />
-        <p className={cn('text-center', 'text-h3', 'font-medium', messageClassName)}>
+        <p className={clsx('text-center', 'text-h3', 'font-medium', messageClassName)}>
           {message}
         </p>
         {message2 && (
-          <p className={cn('text-center', 'text-h3', 'font-medium', messageClassName)}>
+          <p className={clsx('text-center', 'text-h3', 'font-medium', messageClassName)}>
             {message2}
           </p>
         )}

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -3,7 +3,7 @@ import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
 import { cn } from "utils/util";
 
 interface ErrorGraphicProps {
-  iconProp: IconDefinition;
+  icon: IconDefinition;
   message: string;
   message2?: string;
   className?: string;
@@ -11,12 +11,12 @@ interface ErrorGraphicProps {
   messageClassName: string
 }
 
-export default function ErrorGraphic({ className, iconProp, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
+export default function ErrorGraphic({ className, icon, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
     return (
       <div className={cn('flex', 'h-full', 'w-full', 'grow', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'bg-gray-800', className)}>
         <FontAwesomeIcon
-          icon={iconProp}
-          className={cn('text-title', iconClassName)}
+          icon={icon}
+          className={`text-title ${iconClassName}`}
         />
         <p className={cn('text-center', 'text-h3', 'font-medium', messageClassName)}>
           {message}

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
-// import * as fileIcon from "@fortawesome/free-solid-svg-icons"
+import { cn } from "utils/util";
 
 interface ErrorGraphicProps {
   iconProp: IconDefinition;
@@ -12,16 +12,16 @@ interface ErrorGraphicProps {
 }
 export default function ErrorGraphic({ className, iconProp, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
     return (
-      <div className={`flex h-full w-full grow flex-col items-center justify-center gap-4 bg-gray-800 ${className}`}>
+      <div className={cn('flex', 'h-full', 'w-full', 'grow', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'bg-gray-800', className)}>
         <FontAwesomeIcon
           icon={iconProp}
-          className={`text-title ${iconClassName}`}
+          className={cn('text-title', iconClassName)}
         />
-        <p className={`text-center text-h3 font-medium ${messageClassName}`}>
+        <p className={cn('text-center', 'text-h3', 'font-medium', messageClassName)}>
           {message}
         </p>
         {message2 && (
-          <p className={`text-center text-h3 font-medium ${messageClassName}`}>
+          <p className={cn('text-center', 'text-h3', 'font-medium', messageClassName)}>
             {message2}
           </p>
         )}

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -10,6 +10,7 @@ interface ErrorGraphicProps {
   iconClassName: string;
   messageClassName: string
 }
+
 export default function ErrorGraphic({ className, iconProp, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
     return (
       <div className={cn('flex', 'h-full', 'w-full', 'grow', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'bg-gray-800', className)}>

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -1,21 +1,30 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons"
+// import * as fileIcon from "@fortawesome/free-solid-svg-icons"
 
 interface ErrorGraphicProps {
   iconProp: IconDefinition;
   message: string;
+  message2?: string;
+  className?: string;
+  iconClassName: string;
+  messageClassName: string
 }
-
-export default function ErrorGraphic({ iconProp, message }: ErrorGraphicProps) {
+export default function ErrorGraphic({ className, iconProp, iconClassName, message, message2, messageClassName }: ErrorGraphicProps) {
     return (
-      <div className="flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-t-lg border-b border-gray-faded/30 bg-gray-800">
+      <div className={`flex h-full w-full grow flex-col items-center justify-center gap-4 bg-gray-800 ${className}`}>
         <FontAwesomeIcon
           icon={iconProp}
-          className="text-title text-gray-400"
+          className={`text-title ${iconClassName}`}
         />
-        <p className="text-center text-h3 font-medium text-white/50">
+        <p className={`text-center text-h3 font-medium ${messageClassName}`}>
           {message}
         </p>
+        {message2 && (
+          <p className={`text-center text-h3 font-medium ${messageClassName}`}>
+            {message2}
+          </p>
+        )}
       </div>
     )
 }

--- a/src/components/FileViewer/FileList.tsx
+++ b/src/components/FileViewer/FileList.tsx
@@ -82,8 +82,9 @@ export default function FileList({
           <div
             key={file.path}
             className={clsx(fileTreeEntryClassName, 'hover:bg-gray-700', {
-              'bg-gray-700': fileTicked(file),
-              'bg-gray-800': !fileTicked(file),
+              'bg-gray-900': file === openedFile,
+              'bg-gray-700': fileTicked(file) && file !== openedFile,
+              'bg-gray-800': !fileTicked(file) && file !== openedFile,
             })}
           >
             <Checkbox

--- a/src/components/FileViewer/FileViewer.tsx
+++ b/src/components/FileViewer/FileViewer.tsx
@@ -588,10 +588,16 @@ export default function FileViewer() {
           />
         )}
         <div className="absolute bottom-0 left-0 flex translate-y-full flex-row gap-4 px-4 py-2 text-medium font-medium text-white/50">
-          {tickedFiles.length > 0 && (
+          {tickedFiles.length === 1 && (
+            <div>1 item selected</div>
+          )}
+          {tickedFiles.length > 1 && (
             <div>{tickedFiles.length} items selected</div>
           )}
-          {clipboard.length > 0 && (
+          {clipboard.length === 1 && (
+            <div>1 item in clipboard</div>
+          )}
+          {clipboard.length > 1 && (
             <div>{clipboard.length} items in clipboard</div>
           )}
         </div>

--- a/src/components/FileViewer/FileViewer.tsx
+++ b/src/components/FileViewer/FileViewer.tsx
@@ -560,7 +560,7 @@ export default function FileViewer() {
                     />
                   ) : (
                     <ErrorGraphic
-                      iconProp={faFilePen}
+                      icon={faFilePen}
                       message="File Editor"
                       message2={
                         fileError
@@ -580,7 +580,7 @@ export default function FileViewer() {
           </div>
         ) : (
           <ErrorGraphic
-            iconProp={faFolder}
+            icon={faFolder}
             message="You don't have permission to read this folder"
             className="text-clip rounded-lg border border-gray-faded/30"
             iconClassName="text-gray-400"

--- a/src/components/FileViewer/FileViewer.tsx
+++ b/src/components/FileViewer/FileViewer.tsx
@@ -45,6 +45,7 @@ import { Dialog, Menu, Transition } from '@headlessui/react';
 import { useUserAuthorized } from 'data/UserInfo';
 import { useQueryParam } from 'utils/hooks';
 import { toast } from 'react-toastify';
+import ErrorGraphic from 'components/ErrorGraphic';
 import ConfirmDialog from '../Atoms/ConfirmDialog';
 import FileList from './FileList';
 import CreateFileForm from './CreateFileForm';
@@ -558,37 +559,33 @@ export default function FileViewer() {
                       setFileContent={setFileContent}
                     />
                   ) : (
-                    <div className="flex h-full w-full flex-col items-center justify-center gap-4 bg-gray-800">
-                      <FontAwesomeIcon
-                        icon={faFilePen}
-                        className="text-title text-gray-500"
-                      />
-                      <p className="text-center text-h3 text-gray-400">
-                        File Editor
-                      </p>
-                      <p className="text-center text-h3 text-gray-400">
-                        {fileError
+                    <ErrorGraphic
+                      iconProp={faFilePen}
+                      message="File Editor"
+                      message2={
+                        fileError
                           ? fileError?.message ?? 'Unknown Error'
                           : isFileLoading
                           ? 'Loading...'
-                          : 'Select a file to view its contents'}
-                      </p>
-                    </div>
+                          : 'Select a file to view its contents'
+                      }
+                      className=""
+                      iconClassName="text-gray-500"
+                      messageClassName="text-gray-400"
+                    />
                   )}
                 </div>
               </div>
             )}
           </div>
         ) : (
-          <div className="flex h-full w-full grow flex-col items-center justify-center gap-4 text-clip rounded-lg border border-gray-faded/30 bg-gray-800">
-            <FontAwesomeIcon
-              icon={faFolder}
-              className="text-title text-gray-400"
-            />
-            <p className="text-center text-h3 font-medium text-white/50">
-              You don&#39;t have permission to read this folder
-            </p>
-          </div>
+          <ErrorGraphic
+            iconProp={faFolder}
+            message="You don't have permission to read this folder"
+            className="text-clip rounded-lg border border-gray-faded/30"
+            iconClassName="text-gray-400"
+            messageClassName="text-white/50"
+          />
         )}
         <div className="absolute bottom-0 left-0 flex translate-y-full flex-row gap-4 px-4 py-2 text-medium font-medium text-white/50">
           {tickedFiles.length > 0 && (

--- a/src/components/GameConsole.tsx
+++ b/src/components/GameConsole.tsx
@@ -9,6 +9,7 @@ import { useContext, useEffect } from 'react';
 import { useRef, useState } from 'react';
 import { usePrevious } from 'utils/hooks';
 import { DISABLE_AUTOFILL } from 'utils/util';
+import ErrorGraphic from './ErrorGraphic';
 
 const autoScrollThreshold = 100;
 
@@ -117,25 +118,15 @@ export default function GameConsole() {
         />
       </Tooltip>
       {!canAccessConsole || consoleStatus === 'no-permission' ? (
-        <div className="flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-t-lg border-b border-gray-faded/30 bg-gray-800">
-          <FontAwesomeIcon
-            icon={faServer}
-            className="text-title text-gray-400"
-          />
-          <p className="text-center text-h3 font-medium text-white/50">
-            You don&#39;t have permission to access this console
-          </p>
-        </div>
+        <ErrorGraphic
+          iconProp={faServer}
+          message="You don't have permission to access this console"
+        />
       ) : consoleLog.length === 0 ? (
-        <div className="flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-t-lg border-b border-gray-faded/30 bg-gray-800">
-          <FontAwesomeIcon
-            icon={faServer}
-            className="text-title text-gray-400"
-          />
-          <p className="text-center text-h3 font-medium text-white/50">
-            No console messages yet
-          </p>
-        </div>
+        <ErrorGraphic
+          iconProp={faServer}
+          message="No console messages yet"
+        />
       ) : (
         <ol
           className="font-light flex h-0 grow flex-col overflow-y-auto whitespace-pre-wrap break-words rounded-t-lg border-b border-gray-faded/30 bg-gray-900 py-3 font-mono text-small tracking-tight text-gray-300"

--- a/src/components/GameConsole.tsx
+++ b/src/components/GameConsole.tsx
@@ -119,7 +119,7 @@ export default function GameConsole() {
       </Tooltip>
       {!canAccessConsole || consoleStatus === 'no-permission' ? (
         <ErrorGraphic
-          iconProp={faServer}
+          icon={faServer}
           message="You don't have permission to access this console"
           className="rounded-t-lg border-b border-gray-faded/30"
           iconClassName="text-gray-400"
@@ -127,7 +127,7 @@ export default function GameConsole() {
         />
       ) : consoleLog.length === 0 ? (
         <ErrorGraphic
-          iconProp={faServer}
+          icon={faServer}
           message="No console messages yet"
           className="rounded-t-lg border-b border-gray-faded/30"
           iconClassName="text-gray-400"

--- a/src/components/GameConsole.tsx
+++ b/src/components/GameConsole.tsx
@@ -121,11 +121,17 @@ export default function GameConsole() {
         <ErrorGraphic
           iconProp={faServer}
           message="You don't have permission to access this console"
+          className="rounded-t-lg border-b border-gray-faded/30"
+          iconClassName="text-gray-400"
+          messageClassName="text-white/50"
         />
       ) : consoleLog.length === 0 ? (
         <ErrorGraphic
           iconProp={faServer}
           message="No console messages yet"
+          className="rounded-t-lg border-b border-gray-faded/30"
+          iconClassName="text-gray-400"
+          messageClassName="text-white/50"
         />
       ) : (
         <ol

--- a/src/data/InstanceTabListMap.tsx
+++ b/src/data/InstanceTabListMap.tsx
@@ -53,7 +53,7 @@ const InstanceTabListMap = {
       path: 'console',
       width: 'max-w-6xl',
       icon: <FontAwesomeIcon icon={faServer} />,
-      content: <GameConsole />
+      content: <GameConsole />,
     },
     {
       title: 'Files',

--- a/src/data/InstanceTabListMap.tsx
+++ b/src/data/InstanceTabListMap.tsx
@@ -20,6 +20,8 @@ import {
   faServer,
 } from '@fortawesome/free-solid-svg-icons';
 
+import ErrorGraphic from 'components/ErrorGraphic';
+
 const InstanceTabListMap = {
   minecraft: [
     {
@@ -53,7 +55,16 @@ const InstanceTabListMap = {
       path: 'console',
       width: 'max-w-6xl',
       icon: <FontAwesomeIcon icon={faServer} />,
-      content: <GameConsole />,
+      content: (
+        <>
+          <GameConsole />
+          <ErrorGraphic
+            iconProp={faServer}
+            message="You don't have permission to access this console"
+          />
+        </>
+
+      )
     },
     {
       title: 'Files',

--- a/src/data/InstanceTabListMap.tsx
+++ b/src/data/InstanceTabListMap.tsx
@@ -20,8 +20,6 @@ import {
   faServer,
 } from '@fortawesome/free-solid-svg-icons';
 
-import ErrorGraphic from 'components/ErrorGraphic';
-
 const InstanceTabListMap = {
   minecraft: [
     {
@@ -55,16 +53,7 @@ const InstanceTabListMap = {
       path: 'console',
       width: 'max-w-6xl',
       icon: <FontAwesomeIcon icon={faServer} />,
-      content: (
-        <>
-          <GameConsole />
-          <ErrorGraphic
-            iconProp={faServer}
-            message="You don't have permission to access this console"
-          />
-        </>
-
-      )
+      content: <GameConsole />
     },
     {
       title: 'Files',


### PR DESCRIPTION
# Description

https://github.com/Lodestone-Team/lodestone/issues/157

Created a new component `ErrorGraphic` that is responsible for rendering the UI whenever there is an error for `GameConsole` and `FileViewer`. It is designed so that it can be used with other components as well as it takes props to display the different parts of the error UI.

Also added a dark highlight colour on whichever file you have open to make it easier to tell which one you're on. Also added proper pluralization when listing how many files are selected/in the clipboard.

![image](https://user-images.githubusercontent.com/43940223/222871718-9bcc7ab4-507b-4bfb-af34-3fb9933945e4.png)

# How Has This Been Tested?

The current errors are rendered by checking for conditions to see if there is an error. I "created" the errors by modifying the conditions so that the component would go to render `ErrorGraphic`. It looks identical to how it was before, except now that it is done with the `ErrorGraphic` component instead.

![image](https://user-images.githubusercontent.com/43940223/222863186-4c094db4-6141-49d2-b660-ac5b7c7fbe7b.png)
![image](https://user-images.githubusercontent.com/43940223/222863196-9dfbef6b-efe1-4877-9169-cbd3dbb04346.png)
![image](https://user-images.githubusercontent.com/43940223/222863226-c3156335-6c7e-4b7a-b2d3-d14fff383901.png)
