### PR TITLE
Use appropriated WebSocket protocol based on core protocol

### DIFF
--- a/src/data/ConsoleStream.ts
+++ b/src/data/ConsoleStream.ts
@@ -75,7 +75,7 @@ const toConsoleEvent = (event: ClientEvent): ConsoleEvent => {
  */
 export const useConsoleStream = (uuid: string) => {
   const { core, token } = useContext(LodestoneContext);
-  const { address, port, apiVersion } = core;
+  const { address, port, apiVersion, protocol } = core;
   const [consoleLog, setConsoleLog] = useState<ConsoleEvent[]>([]);
   const [status, setStatusInner] = useState<ConsoleStreamStatus>('loading'); //callbacks should use statusRef.current instead of status
   const statusRef = useRef<ConsoleStreamStatus>('loading');
@@ -118,7 +118,7 @@ export const useConsoleStream = (uuid: string) => {
 
     try {
       const websocket = new WebSocket(
-        `ws://${address}:${
+        `${protocol === 'https' ? 'wss' : 'ws'}://${address}:${
           port ?? LODESTONE_PORT
         }/api/${apiVersion}/instance/${uuid}/console/stream?token=Bearer ${token}`
       );

--- a/src/data/EventStream.ts
+++ b/src/data/EventStream.ts
@@ -394,7 +394,7 @@ export const useEventStream = () => {
     if (!token) return;
 
     const connectWebsocket = () => {
-      const wsAddress = `ws://${core.address}:${
+      const wsAddress = `${core.protocol === 'https' ? 'wss' : 'ws'}://${core.address}:${
         core.port ?? LODESTONE_PORT
       }/api/${core.apiVersion}/events/all/stream?filter=${JSON.stringify(
         eventQuery

--- a/src/data/PerformanceStream.ts
+++ b/src/data/PerformanceStream.ts
@@ -27,7 +27,7 @@ export const usePerformanceStream = (uuid: string) => {
   const [latency_s, setLatency_s] = useState(0);
   const [counter, setCounter] = useState(-1);
   const { core } = useContext(LodestoneContext);
-  const { address, port, apiVersion } = core;
+  const { address, port, apiVersion, protocol } = core;
 
   useInterval(() => {
     setLatency_s((Date.now() - lastPing) / 1000);
@@ -36,7 +36,7 @@ export const usePerformanceStream = (uuid: string) => {
   useEffect(() => {
     try {
       const websocket = new WebSocket(
-        `ws://${address}:${
+        `${protocol === 'https' ? 'wss' : 'ws'}://${address}:${
           port ?? LODESTONE_PORT
         }/api/${apiVersion}/monitor/${uuid}`
       );


### PR DESCRIPTION
Firefox and Chrome don't allow HTTP connections if the website is using HTTPS, This breaks all streams in Firefox, but Chrome still allows insecure WebSocket connections.
I changed the WebSocket connections to use WSS if the core is set up to use HTTPS, so anyone hosting their own Core and only allowing HTTPS connections can use the webapp (lodestone.cc) to manage it.
Now in Firefox, the Console and Overview update immediately and the Core status is no more "Degraded"