### PR TITLE
Fix password length

### DIFF
--- a/src/components/Atoms/Config/InputBox.tsx
+++ b/src/components/Atoms/Config/InputBox.tsx
@@ -168,12 +168,15 @@ export default function InputBox({
 
   let icons = [];
 
-  if (touched) {
+  if (typeModified !== 'password' && touched) {
     icons.push(
       <FontAwesomeIcon
         icon={faFloppyDisk}
         className="w-4 text-gray-faded/30 hover:cursor-pointer hover:text-gray-500"
-        onClick={() => formRef.current?.requestSubmit()}
+        onClick={() => {
+          formRef.current?.requestSubmit();
+          setTypeModified('password');
+        }}
         key="save"
       />
     );
@@ -191,11 +194,12 @@ export default function InputBox({
       <FontAwesomeIcon
         icon={typeModified === 'password' ? faEye : faEyeSlash}
         className="w-4 text-gray-faded/30 hover:cursor-pointer hover:text-gray-500"
-        onClick={() =>
+        onClick={() => {
           typeModified === 'password'
             ? setTypeModified('text')
-            : setTypeModified('password')
-        }
+            : setTypeModified('password');
+          formRef.current?.reset();
+        }}
         key="reveal password"
       />
     );
@@ -249,7 +253,7 @@ export default function InputBox({
           </div>
         </div>
         <input
-          value={value}
+          value={typeModified === 'password' ? 'xxxxxxxx' : value}
           placeholder={placeholder}
           onChange={onChange}
           maxLength={maxLength}
@@ -261,7 +265,7 @@ export default function InputBox({
           onBlur={() => {
             setValue(value.trim());
           }}
-          disabled={disabled}
+          disabled={typeModified === 'password' ? true : disabled}
           type={typeModified}
           autoComplete={DISABLE_AUTOFILL}
         />


### PR DESCRIPTION
Modified Input Box password logic:

- Password cannot be edited until the user clicks on the eye to make the password "visible"
- When the user saves password changes, the input box reverts to its disabled password state
- When the user clicks on the eye again, any changes will be undone if they do not save

![image](https://user-images.githubusercontent.com/83772958/225202503-0eba1ad7-c8aa-428c-ba54-2653634ba071.png)
