### PR TITLE
Fixed typo when turning off safe mode

### DIFF
--- a/src/components/Settings/CoreSettings.tsx
+++ b/src/components/Settings/CoreSettings.tsx
@@ -212,9 +212,9 @@ export const CoreSettings = () => {
         closeButtonText="Cancel"
         type={'info'}
       >
-        Are you sure you want to turn off safe mode? This will allow all you to
+        Are you sure you want to turn off safe mode? This will allow you to
         give users other than yourself the ability to run potentially dangerous
-        commands. Make sure you trust all users you give these permissions to
+        commands. Make sure you trust all the users you give these permissions to.
       </ConfirmDialog>
       {openPortModal}
       <div className="flex w-full flex-col gap-4 @4xl:flex-row">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/43940223/228725909-38eb2da7-2446-4036-932f-dd8c73c1165b.png)

After:
![image](https://user-images.githubusercontent.com/43940223/228725958-e11ee73e-7153-4c52-a36b-7e591bb47c01.png)

That's it