### PR TITLE
Add alignment options and generic button menu to table component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lodestone",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lodestone",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.2",

--- a/src/components/Atoms/Button.stories.tsx
+++ b/src/components/Atoms/Button.stories.tsx
@@ -32,5 +32,5 @@ StartServer.args = {
   onClick: () => {
     console.log('Start Server');
   },
-  iconRight: faServer,
+  icon: faServer,
 };

--- a/src/components/Atoms/Button.stories.tsx
+++ b/src/components/Atoms/Button.stories.tsx
@@ -32,5 +32,5 @@ StartServer.args = {
   onClick: () => {
     console.log('Start Server');
   },
-  icon: faServer,
+  iconRight: faServer,
 };

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -70,7 +70,7 @@ export interface ButtonProps extends VariantProps<typeof buttonClasses> {
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   type?: 'button' | 'submit' | 'reset';
   iconComponent?: React.ReactNode;
-  iconLeft?: IconDefinition;
+  icon?: IconDefinition;
   iconRight?: IconDefinition;
   labelGrow?: boolean;
   form?: string;
@@ -90,7 +90,7 @@ const Button = forwardRef(
       variant,
       className,
       iconComponent,
-      iconLeft,
+      icon,
       iconRight,
       labelGrow = false,
       type = 'button',
@@ -110,7 +110,7 @@ const Button = forwardRef(
         {...props}
       >
         {iconComponent}
-        {iconLeft && <FontAwesomeIcon icon={iconLeft} className="w-4 pr-2 opacity-50" />}
+        {icon && <FontAwesomeIcon icon={icon} className="w-4 pr-2 opacity-50" />}
         <div
           className={cn('flex items-center truncate', labelGrow && 'grow')}
           style={{ justifyContent: 'inherit' }}

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -102,7 +102,7 @@ const Button = forwardRef(
       <button
         className={myTwMerge(
           buttonClasses({ align, intention, size, variant }),
-          className
+          className, 'w-full'
         )}
         disabled={disabled || loading}
         ref={ref}

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -1,6 +1,6 @@
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { forwardRef } from 'react';
+import { DOMAttributes, forwardRef } from 'react';
 import clsx from 'clsx';
 import { BeatLoader } from 'react-spinners';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -102,7 +102,7 @@ const Button = forwardRef(
       <button
         className={myTwMerge(
           buttonClasses({ align, intention, size, variant }),
-          className, 'w-full'
+          className
         )}
         disabled={disabled || loading}
         ref={ref}
@@ -110,7 +110,7 @@ const Button = forwardRef(
         {...props}
       >
         {iconComponent}
-        {icon && <FontAwesomeIcon icon={icon} className="w-4 pr-2 opacity-50" />}
+        {icon && <FontAwesomeIcon icon={icon} className="w-4 opacity-50" />}
         <div
           className={cn('flex items-center truncate', labelGrow && 'grow')}
           style={{ justifyContent: 'inherit' }}
@@ -127,7 +127,7 @@ const Button = forwardRef(
           </div>
         </div>
         {iconRight && (
-          <FontAwesomeIcon icon={iconRight} className="w-4 pl-2 opacity-50" />
+          <FontAwesomeIcon icon={iconRight} className="w-4 opacity-50" />
         )}
       </button>
     );

--- a/src/components/Atoms/Button.tsx
+++ b/src/components/Atoms/Button.tsx
@@ -1,6 +1,6 @@
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { DOMAttributes, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import clsx from 'clsx';
 import { BeatLoader } from 'react-spinners';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -70,7 +70,7 @@ export interface ButtonProps extends VariantProps<typeof buttonClasses> {
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   type?: 'button' | 'submit' | 'reset';
   iconComponent?: React.ReactNode;
-  icon?: IconDefinition;
+  iconLeft?: IconDefinition;
   iconRight?: IconDefinition;
   labelGrow?: boolean;
   form?: string;
@@ -90,7 +90,7 @@ const Button = forwardRef(
       variant,
       className,
       iconComponent,
-      icon,
+      iconLeft,
       iconRight,
       labelGrow = false,
       type = 'button',
@@ -110,7 +110,7 @@ const Button = forwardRef(
         {...props}
       >
         {iconComponent}
-        {icon && <FontAwesomeIcon icon={icon} className="w-4 opacity-50" />}
+        {iconLeft && <FontAwesomeIcon icon={iconLeft} className="w-4 pr-2 opacity-50" />}
         <div
           className={cn('flex items-center truncate', labelGrow && 'grow')}
           style={{ justifyContent: 'inherit' }}
@@ -126,9 +126,8 @@ const Button = forwardRef(
             <span className={clsx(loading && 'opacity-0')}>{label}</span>
           </div>
         </div>
-
         {iconRight && (
-          <FontAwesomeIcon icon={iconRight} className="w-4 opacity-50" />
+          <FontAwesomeIcon icon={iconRight} className="w-4 pl-2 opacity-50" />
         )}
       </button>
     );

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -3,6 +3,7 @@ import Button from './Atoms/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import clsx from 'clsx';
 
 interface MenuItemProperty {
   className?: string;
@@ -35,7 +36,7 @@ export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical 
           {menuItems.map((menuItem, index) => (
             <Menu.Item key={index}>
               <Button
-                className={menuItem.className}
+                className={clsx(menuItem.className, "w-full gap-2.5")}
                 label={menuItem.label}
                 iconRight={menuItem.icon}
                 variant={menuItem.variant}

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -1,0 +1,51 @@
+import { Menu } from '@headlessui/react';
+import Button from './Atoms/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+
+interface MenuItemProperty {
+  className?: string;
+  label: string;
+  icon: IconDefinition;
+  variant?: 'contained' | 'text';
+  intention?: 'none' | 'info' | 'danger' | 'primary';
+  disabled: boolean;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export interface MenuItemProps {
+  menuItems: MenuItemProperty[];
+}
+
+export default function ButtonMenu({ menuItems }: MenuItemProps) {
+
+  return (
+    <Menu as="div" className="relative inline-block text-right">
+      <Menu.Button
+        as={FontAwesomeIcon}
+        icon={faEllipsisVertical}
+        className="h-4 w-4 select-none text-h2 text-white/50 hover:cursor-pointer hover:text-white/75"
+      />
+      <Menu.Items className="absolute right-0 z-10 mt-0.5 origin-top-left divide-y divide-gray-faded/30 rounded border border-gray-faded/30 bg-gray-800 drop-shadow-md focus:outline-none">
+        <div className="py-2 px-1.5">
+          {menuItems.map((menuItem, index) => (
+            <Menu.Item key={index}>
+              <Button
+                className={menuItem.className}
+                label={menuItem.label}
+                iconRight={menuItem.icon}
+                variant={menuItem.variant}
+                intention={menuItem.intention}
+                align="end"
+                disabled={menuItem.disabled}
+                onClick={menuItem.onClick}
+              />
+            </Menu.Item>
+          ))}
+        </div>
+      </Menu.Items>
+    </Menu>
+  )
+}

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -14,12 +14,12 @@ interface MenuItemProperty {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export interface MenuItemProps {
+export interface ButtonMenuProps {
   menuItems: MenuItemProperty[];
   buttonIcon?: IconDefinition;
 }
 
-export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical }: MenuItemProps) {
+export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical }: ButtonMenuProps) {
   return (
     <Menu as="div" className="relative inline-block text-right">
       <Menu.Button

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -27,7 +27,10 @@ export default function ButtonMenu({ menuItems }: MenuItemProps) {
         icon={faEllipsisVertical}
         className="h-4 w-4 select-none text-h2 text-white/50 hover:cursor-pointer hover:text-white/75"
       />
-      <Menu.Items className="absolute right-0 z-10 mt-0.5 origin-top-left divide-y divide-gray-faded/30 rounded border border-gray-faded/30 bg-gray-800 drop-shadow-md focus:outline-none">
+      <Menu.Items
+        className="absolute right-0 z-10 mt-0.5 origin-top-left divide-y divide-gray-faded/30
+          rounded border border-gray-faded/30 bg-gray-800 drop-shadow-md focus:outline-none"
+      >
         <div className="py-2 px-1.5">
           {menuItems.map((menuItem, index) => (
             <Menu.Item key={index}>
@@ -46,5 +49,5 @@ export default function ButtonMenu({ menuItems }: MenuItemProps) {
         </div>
       </Menu.Items>
     </Menu>
-  )
+  );
 }

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -16,14 +16,15 @@ interface MenuItemProperty {
 
 export interface MenuItemProps {
   menuItems: MenuItemProperty[];
+  buttonIcon?: IconDefinition;
 }
 
-export default function ButtonMenu({ menuItems }: MenuItemProps) {
+export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical }: MenuItemProps) {
   return (
     <Menu as="div" className="relative inline-block text-right">
       <Menu.Button
         as={FontAwesomeIcon}
-        icon={faEllipsisVertical}
+        icon={buttonIcon}
         className="h-4 w-4 select-none text-h2 text-white/50 hover:cursor-pointer hover:text-white/75"
       />
       <Menu.Items
@@ -39,7 +40,7 @@ export default function ButtonMenu({ menuItems }: MenuItemProps) {
                 iconRight={menuItem.icon}
                 variant={menuItem.variant}
                 intention={menuItem.intention}
-                align="end"
+                align="between"
                 disabled={menuItem.disabled}
                 onClick={menuItem.onClick}
               />

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -2,7 +2,6 @@ import { Menu } from '@headlessui/react';
 import Button from './Atoms/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
-
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 
 interface MenuItemProperty {
@@ -28,7 +27,7 @@ export default function ButtonMenu({ menuItems }: MenuItemProps) {
         className="h-4 w-4 select-none text-h2 text-white/50 hover:cursor-pointer hover:text-white/75"
       />
       <Menu.Items
-        className="absolute right-0 z-10 mt-0.5 origin-top-left divide-y divide-gray-faded/30
+        className="absolute top-0 right-5 z-10 mr-0.5 divide-y divide-gray-faded/30
           rounded border border-gray-faded/30 bg-gray-800 drop-shadow-md focus:outline-none"
       >
         <div className="py-2 px-1.5">

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -1,26 +1,34 @@
-import { Menu } from '@headlessui/react';
 import Button from './Atoms/Button';
+import { TableRow } from './Table';
+import { Menu } from '@headlessui/react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+
 import clsx from 'clsx';
 
-interface MenuItemProperty {
+interface MenuItemProperties {
   className?: string;
   label: string;
   icon: IconDefinition;
   variant?: 'contained' | 'text';
   intention?: 'none' | 'info' | 'danger' | 'primary';
   disabled: boolean;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick: (row: TableRow) => void;
 }
 
-export interface ButtonMenuProps {
-  menuItems: MenuItemProperty[];
+export interface ButtonMenuConfig {
+  tableRows: TableRow[];
+  menuItems: MenuItemProperties[];
   buttonIcon?: IconDefinition;
 }
 
-export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical }: ButtonMenuProps) {
+interface ButtonMenuProps extends ButtonMenuConfig {
+  rowIndex: number;
+}
+
+export default function ButtonMenu({ tableRows, rowIndex, menuItems, buttonIcon = faEllipsisVertical }: ButtonMenuProps) {
   return (
     <Menu as="div" className="relative inline-block text-right">
       <Menu.Button
@@ -29,7 +37,7 @@ export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical 
         className="h-4 w-4 select-none text-h2 text-white/50 hover:cursor-pointer hover:text-white/75"
       />
       <Menu.Items
-        className="absolute top-0 right-5 z-10 mr-0.5 divide-y divide-gray-faded/30
+        className="absolute top-0 right-5 z-50 mr-0.5 divide-y divide-gray-faded/30
           rounded border border-gray-faded/30 bg-gray-800 drop-shadow-md focus:outline-none"
       >
         <div className="py-2 px-1.5">
@@ -43,7 +51,7 @@ export default function ButtonMenu({ menuItems, buttonIcon = faEllipsisVertical 
                 intention={menuItem.intention}
                 align="between"
                 disabled={menuItem.disabled}
-                onClick={menuItem.onClick}
+                onClick={() => menuItem.onClick(tableRows[rowIndex])}
               />
             </Menu.Item>
           ))}

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -20,7 +20,6 @@ export interface MenuItemProps {
 }
 
 export default function ButtonMenu({ menuItems }: MenuItemProps) {
-
   return (
     <Menu as="div" className="relative inline-block text-right">
       <Menu.Button

--- a/src/components/ErrorGraphic.tsx
+++ b/src/components/ErrorGraphic.tsx
@@ -27,5 +27,5 @@ export default function ErrorGraphic({ className, icon, iconClassName, message, 
           </p>
         )}
       </div>
-    )
+    );
 }

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -93,10 +93,32 @@ const InstanceOverview = () => {
     { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
     { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
     { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
-    { id: 5, make: 'Hasselblad Hasselblad Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
+    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
     { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
     { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
     { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
+    { id: 9, make: 'Rollei', model: '35T', lens: '40mm f/3.5', format: '35mm', year: 1960 },
+    { id: 10, make: 'Kodak', model: 'Retina IIc', lens: '50mm f/2.8', format: '35mm', year: 1954 },
+    { id: 11, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
+    { id: 12, make: 'Voigtlander', model: 'Bessa R3A', lens: '40mm f/1.4', format: '35mm', year: 2004 },
+    { id: 13, make: 'Zenza Bronica', model: 'SQ-Ai', lens: '80mm f/2.8', format: '120', year: 1982 },
+    { id: 14, make: 'Konica', model: 'Hexar AF', lens: '35mm f/2.0', format: '35mm', year: 1993 },
+    { id: 15, make: 'Zeiss Ikon Zeiss Ikon Zeiss Ikon Zeiss Ikon', model: 'Contessa S310', lens: '45mm f/2.8', format: '35mm', year: 1957 },
+    { id: 16, make: 'what the fuck am i doing like, the hell i am looooong words', model: 'Instax Mini 9', lens: '60mm f/12.7', format: 'Instant', year: 2017 },
+    // { id: 17, make: 'Polaroid', model: 'SX-70', lens: '116mm f/8', format: 'Polaroid', year: 1972 },
+    // { id: 18, make: 'Fujifilm', model: 'Instax Mini 90', lens: '60mm f/12.7', format: 'Instant', year: 2013 },
+    // { id: 19, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
+    // { id: 20, make: 'Holga', model: '120N', lens: '60mm f/8', format: '120', year: 1982 },
+    // { id: 21, make: 'Kodak', model: 'Brownie Hawkeye', lens: '75mm f/14.5', format: '620', year: 1949 },
+    // { id: 22, make: 'Rollei', model: '35', lens: '40mm f/3.5', format: '35mm', year: 1966 },
+    // { id: 23, make: 'Agfa', model: 'Clack', lens: '95mm f/11', format: '120', year: 1954 },
+    // { id: 24, make: 'Lomography', model: 'Diana F+', lens: '75mm f/8', format: '120', year: 2007 },
+    // { id: 25, make: 'Pentax', model: '645', lens: '75mm f/2.8', format: '120', year: 1984 },
+    // { id: 26, make: 'Nimslo', model: 'Nimslo 3D', lens: '30mm f/5.6', format: '35mm', year: 1980 },
+    // { id: 27, make: 'Voigtlander', model: 'Bessa R2A', lens: '50mm f/1.5', format: '35mm', year: 2004 },
+    // { id: 28, make: 'Fujifilm', model: 'GFX 50S', lens: '63mm f/2.8', format: 'Medium Format', year: 2017 },
+    // { id: 29, make: 'Bronica', model: 'SQ-A', lens: '80mm f/2.8', format: 'Medium Format', year: 1980 },
+    // { id: 30, make: 'Minox', model: '35 EL', lens: '35mm f/2.8', format: '35mm', year: 1974 },
   ];
 
   const menuItems1: ButtonMenuProps = {
@@ -176,7 +198,8 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='auto' />
+      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' />
+      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='even' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -16,18 +16,7 @@ import InstancePlayerList from './InstancePlayerList';
 
 import { Table, TableColumn, TableRow } from 'components/Table';
 import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
-import { MenuItemProps } from 'components/ButtonMenu';
-
-interface FilmCameraRow {
-  id: number;
-  make: string;
-  model: string;
-  lens: string;
-  aperture: string;
-  shutterSpeed: string;
-  format: string;
-  year: number;
-}
+import { ButtonMenuProps } from 'components/ButtonMenu';
 
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
@@ -119,7 +108,7 @@ const InstanceOverview = () => {
     { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
   ];
 
-  const menuItems1: MenuItemProps = {
+  const menuItems1: ButtonMenuProps = {
     menuItems: [
       {
         label: 'Edit in file viewer',

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -68,41 +68,32 @@ const InstanceOverview = () => {
     }));
   };
 
-  const columns: TableColumn[] = [
-    { field: 'name', headerName: 'Name' },
-    { field: 'age', headerName: 'Age' },
-    { field: 'city', headerName: 'City', className: 'column-city' },
+  const columnsBasic: TableColumn[] = [
+    { field: 'name', headerName: 'NAME' },
+    { field: 'age', headerName: 'AGE' },
+    { field: 'city', headerName: 'CITY' },
   ];
 
-  const rows: TableRow[] = [
+  const rowsBasic: TableRow[] = [
     { id: 1, name: 'John', age: 30, city: 'New York' },
     { id: 2, name: 'Jane', age: 25, city: 'Los Angeles' },
     { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
   ];
 
   const columnsAnalog: TableColumn[] = [
-    { field: 'make', headerName: 'Make' },
-    { field: 'model', headerName: 'Model' },
-    { field: 'lens', headerName: 'Lens' },
-    { field: 'format', headerName: 'Format' },
-    { field: 'year', headerName: 'Year' },
+    { field: 'make', headerName: 'MAKE' },
+    { field: 'model', headerName: 'MODEL' },
+    { field: 'lens', headerName: 'LENS' },
+    { field: 'format', headerName: 'FORMAT' },
+    { field: 'year', headerName: 'YEAR' },
   ];
   
-  const rowsAnalog1: TableRow[] = [
+  const rowsAnalog: TableRow[] = [
     { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
     { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
     { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
     { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
-    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
-    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
-  ];
-  
-  const rowsAnalog2: TableRow[] = [
-    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
-    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
-    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
-    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
-    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
+    { id: 5, make: 'Hasselblad Hasselblad Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
     { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
     { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
     { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
@@ -119,7 +110,7 @@ const InstanceOverview = () => {
         onClick: () => console.log('Button 1 clicked'),
       },
       {
-        label: 'why the fuck is this justified start',
+        label: 'another one',
         icon: faSkull,
         variant: 'text',
         intention: 'info',
@@ -185,7 +176,7 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      <Table rows={rowsAnalog1} columns={columnsAnalog} menuOptions={menuItems1} />
+      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='auto' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -16,6 +16,9 @@ import InstancePlayerList from './InstancePlayerList';
 
 import { Table } from 'components/Table';
 
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import { MenuItemProps } from 'components/ButtonMenu';
+
 export interface TableColumn {
   field: string;
   headerName: string;
@@ -25,6 +28,17 @@ export interface TableColumn {
 export interface TableRow {
   [key: string]: React.ReactNode;
 } 
+
+interface FilmCameraRow {
+  id: number;
+  make: string;
+  model: string;
+  lens: string;
+  aperture: string;
+  shutterSpeed: string;
+  format: string;
+  year: number;
+}
 
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
@@ -88,6 +102,54 @@ const InstanceOverview = () => {
     { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
   ];
 
+  const columnsAnalog: TableColumn[] = [
+    { field: 'make', headerName: 'Make' },
+    { field: 'model', headerName: 'Model' },
+    { field: 'lens', headerName: 'Lens' },
+    { field: 'format', headerName: 'Format' },
+    { field: 'year', headerName: 'Year' },
+  ];
+  
+  const rowsAnalog1: TableRow[] = [
+    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
+    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
+    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
+    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
+    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
+  ];
+  
+  const rowsAnalog2: TableRow[] = [
+    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
+    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
+    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
+    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
+    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
+    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
+    { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
+    { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
+  ];
+
+  const menuItems1: MenuItemProps = {
+    menuItems: [
+      {
+        label: 'Edit in file viewer',
+        icon: faEllipsisVertical,
+        variant: 'text',
+        intention: 'info',
+        disabled: false,
+        onClick: () => console.log('Button 1 clicked'),
+      },
+      {
+        label: 'Delete',
+        icon: faEllipsisVertical,
+        variant: 'text',
+        intention: 'danger',
+        disabled: false,
+        onClick: () => console.log('Button 2 clicked'),
+      },
+    ]
+  };
+
   return (
     <>
       <div
@@ -136,7 +198,7 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      <Table rows={rows} columns={columns} />
+      <Table rows={rowsAnalog1} columns={columnsAnalog} menuOptions={menuItems1} />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -14,10 +14,6 @@ import { useGlobalSettings } from 'data/GlobalSettings';
 import { useDocumentTitle } from 'usehooks-ts';
 import InstancePlayerList from './InstancePlayerList';
 
-import { Table, TableColumn, TableRow } from 'components/Table';
-import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
-import { ButtonMenuProps } from 'components/ButtonMenu';
-
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
   const { core } = useContext(LodestoneContext);
@@ -68,88 +64,6 @@ const InstanceOverview = () => {
     }));
   };
 
-  const columnsBasic: TableColumn[] = [
-    { field: 'name', headerName: 'NAME' },
-    { field: 'age', headerName: 'AGE' },
-    { field: 'city', headerName: 'CITY' },
-  ];
-
-  const rowsBasic: TableRow[] = [
-    { id: 1, name: 'John', age: 30, city: 'New York' },
-    { id: 2, name: 'Jane', age: 25, city: 'Los Angeles' },
-    { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
-  ];
-
-  const columnsAnalog: TableColumn[] = [
-    { field: 'make', headerName: 'MAKE' },
-    { field: 'model', headerName: 'MODEL' },
-    { field: 'lens', headerName: 'LENS' },
-    { field: 'format', headerName: 'FORMAT' },
-    { field: 'year', headerName: 'YEAR' },
-  ];
-  
-  const rowsAnalog: TableRow[] = [
-    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
-    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
-    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
-    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
-    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
-    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
-    { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
-    { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
-    { id: 9, make: 'Rollei', model: '35T', lens: '40mm f/3.5', format: '35mm', year: 1960 },
-    { id: 10, make: 'Kodak', model: 'Retina IIc', lens: '50mm f/2.8', format: '35mm', year: 1954 },
-    { id: 11, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
-    { id: 12, make: 'Voigtlander', model: 'Bessa R3A', lens: '40mm f/1.4', format: '35mm', year: 2004 },
-    { id: 13, make: 'Zenza Bronica', model: 'SQ-Ai', lens: '80mm f/2.8', format: '120', year: 1982 },
-    { id: 14, make: 'Konica', model: 'Hexar AF', lens: '35mm f/2.0', format: '35mm', year: 1993 },
-    { id: 15, make: 'Zeiss Ikon Zeiss Ikon Zeiss Ikon Zeiss Ikon', model: 'Contessa S310', lens: '45mm f/2.8', format: '35mm', year: 1957 },
-    { id: 16, make: 'what the fuck am i doing like, the hell i am looooong words', model: 'Instax Mini 9', lens: '60mm f/12.7', format: 'Instant', year: 2017 },
-    // { id: 17, make: 'Polaroid', model: 'SX-70', lens: '116mm f/8', format: 'Polaroid', year: 1972 },
-    // { id: 18, make: 'Fujifilm', model: 'Instax Mini 90', lens: '60mm f/12.7', format: 'Instant', year: 2013 },
-    // { id: 19, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
-    // { id: 20, make: 'Holga', model: '120N', lens: '60mm f/8', format: '120', year: 1982 },
-    // { id: 21, make: 'Kodak', model: 'Brownie Hawkeye', lens: '75mm f/14.5', format: '620', year: 1949 },
-    // { id: 22, make: 'Rollei', model: '35', lens: '40mm f/3.5', format: '35mm', year: 1966 },
-    // { id: 23, make: 'Agfa', model: 'Clack', lens: '95mm f/11', format: '120', year: 1954 },
-    // { id: 24, make: 'Lomography', model: 'Diana F+', lens: '75mm f/8', format: '120', year: 2007 },
-    // { id: 25, make: 'Pentax', model: '645', lens: '75mm f/2.8', format: '120', year: 1984 },
-    // { id: 26, make: 'Nimslo', model: 'Nimslo 3D', lens: '30mm f/5.6', format: '35mm', year: 1980 },
-    // { id: 27, make: 'Voigtlander', model: 'Bessa R2A', lens: '50mm f/1.5', format: '35mm', year: 2004 },
-    // { id: 28, make: 'Fujifilm', model: 'GFX 50S', lens: '63mm f/2.8', format: 'Medium Format', year: 2017 },
-    // { id: 29, make: 'Bronica', model: 'SQ-A', lens: '80mm f/2.8', format: 'Medium Format', year: 1980 },
-    // { id: 30, make: 'Minox', model: '35 EL', lens: '35mm f/2.8', format: '35mm', year: 1974 },
-  ];
-
-  const menuItems1: ButtonMenuProps = {
-    menuItems: [
-      {
-        label: 'Edit in file viewer',
-        icon: faEdit,
-        variant: 'text',
-        intention: 'info',
-        disabled: false,
-        onClick: () => console.log('Button 1 clicked'),
-      },
-      {
-        label: 'another one',
-        icon: faSkull,
-        variant: 'text',
-        intention: 'info',
-        disabled: false,
-        onClick: () => console.log('Button 1 clicked'),
-      },
-      {
-        label: 'Obliterate',
-        icon: faTrashCan,
-        variant: 'text',
-        intention: 'danger',
-        disabled: false,
-        onClick: () => console.log('Button 2 clicked'),
-      },
-    ]
-  };
-
   return (
     <>
       <div
@@ -198,8 +112,6 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' />
-      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='even' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -14,10 +14,6 @@ import { useGlobalSettings } from 'data/GlobalSettings';
 import { useDocumentTitle } from 'usehooks-ts';
 import InstancePlayerList from './InstancePlayerList';
 
-import { Table, TableColumn, TableRow } from 'components/Table';
-import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
-import { ButtonMenuConfig } from 'components/ButtonMenu';
-
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
   const { core } = useContext(LodestoneContext);
@@ -66,91 +62,7 @@ const InstanceOverview = () => {
       ...oldData,
       description,
     }));
-  };
-
-  const columnsBasic: TableColumn[] = [
-    { field: 'name', headerName: 'NAME' },
-    { field: 'age', headerName: 'AGE' },
-    { field: 'city', headerName: 'CITY' },
-  ];
-
-  const rowsBasic: TableRow[] = [
-    { id: 1, name: 'John', age: 30, city: 'New York' },
-    { id: 2, name: 'Jane', age: 25, city: 'Los Angeles' },
-    { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
-  ];
-
-  const columnsAnalog: TableColumn[] = [
-    { field: 'make', headerName: 'MAKE' },
-    { field: 'model', headerName: 'MODEL' },
-    { field: 'lens', headerName: 'LENS' },
-    { field: 'format', headerName: 'FORMAT' },
-    { field: 'year', headerName: 'YEAR' },
-  ];
-  
-  const rowsAnalog: TableRow[] = [
-    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
-    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
-    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
-    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
-    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
-    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
-    { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
-    { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
-    { id: 9, make: 'Rollei', model: '35T', lens: '40mm f/3.5', format: '35mm', year: 1960 },
-    { id: 10, make: 'Kodak', model: 'Retina IIc', lens: '50mm f/2.8', format: '35mm', year: 1954 },
-    { id: 11, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
-    { id: 12, make: 'Voigtlander', model: 'Bessa R3A', lens: '40mm f/1.4', format: '35mm', year: 2004 },
-    { id: 13, make: 'Zenza Bronica', model: 'SQ-Ai', lens: '80mm f/2.8', format: '120', year: 1982 },
-    { id: 14, make: 'Konica', model: 'Hexar AF', lens: '35mm f/2.0', format: '35mm', year: 1993 },
-    { id: 15, make: 'Zeiss Ikon', model: 'Contessa S310', lens: '45mm f/2.8', format: '35mm', year: 1957 },
-    { id: 16, make: 'Fujifilm', model: 'Instax Mini 9', lens: '60mm f/12.7', format: 'Instant', year: 2017 },
-    { id: 17, make: 'Polaroid', model: 'SX-70', lens: '116mm f/8', format: 'Polaroid', year: 1972 },
-    { id: 18, make: 'Fujifilm', model: 'Instax Mini 90', lens: '60mm f/12.7', format: 'Instant', year: 2013 },
-    { id: 19, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
-    { id: 20, make: 'Holga', model: '120N', lens: '60mm f/8', format: '120', year: 1982 },
-    { id: 21, make: 'Kodak', model: 'Brownie Hawkeye', lens: '75mm f/14.5', format: '620', year: 1949 },
-    { id: 22, make: 'Rollei', model: '35', lens: '40mm f/3.5', format: '35mm', year: 1966 },
-    { id: 23, make: 'Agfa', model: 'Clack', lens: '95mm f/11', format: '120', year: 1954 },
-    { id: 24, make: 'Lomography', model: 'Diana F+', lens: '75mm f/8', format: '120', year: 2007 },
-    { id: 25, make: 'Pentax', model: '645', lens: '75mm f/2.8', format: '120', year: 1984 },
-    { id: 26, make: 'Nimslo', model: 'Nimslo 3D', lens: '30mm f/5.6', format: '35mm', year: 1980 },
-    { id: 27, make: 'Voigtlander', model: 'Bessa R2A', lens: '50mm f/1.5', format: '35mm', year: 2004 },
-    { id: 28, make: 'Fujifilm', model: 'GFX 50S', lens: '63mm f/2.8', format: 'Medium Format', year: 2017 },
-    { id: 29, make: 'Bronica', model: 'SQ-A', lens: '80mm f/2.8', format: 'Medium Format', year: 1980 },
-    { id: 30, make: 'Minox', model: '35 EL', lens: '35mm f/2.8', format: '35mm', year: 1974 },
-  ];
-
-  const menuItems1: ButtonMenuConfig = {
-    tableRows: rowsAnalog,
-    menuItems: [
-      {
-        label: 'Edit in file viewer',
-        icon: faEdit,
-        variant: 'text',
-        intention: 'info',
-        disabled: false,
-        onClick: (row: TableRow) => console.log(`Edit on ${row.id}: ${row.make} ${row.model}`),
-      },
-      {
-        label: 'another one',
-        icon: faSkull,
-        variant: 'text',
-        intention: 'info',
-        disabled: false,
-        onClick: (row: TableRow) => console.log(`Another on ${row.id}: ${row.make} ${row.model}`),
-      },
-      {
-        label: 'Obliterate',
-        icon: faTrashCan,
-        variant: 'text',
-        intention: 'danger',
-        disabled: false,
-        onClick: (row: TableRow) => console.log(`Obliterate on ${row.id}: ${row.make} ${row.model}`),
-      },
-    ],
-  };
-  
+  };  
 
   return (
     <>
@@ -200,8 +112,6 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      {/* <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' /> */}
-      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='left' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -62,7 +62,7 @@ const InstanceOverview = () => {
       ...oldData,
       description,
     }));
-  };  
+  };
 
   return (
     <>

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -2,7 +2,7 @@ import ClipboardTextfield from 'components/ClipboardTextfield';
 import Label from 'components/Atoms/Label';
 import { updateInstance } from 'data/InstanceList';
 import { LodestoneContext } from 'data/LodestoneContext';
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { axiosPutSingleValue, stateToLabelColor } from 'utils/util';
 import EditableTextfield from 'components/EditableTextfield';
 import { useQueryClient } from '@tanstack/react-query';
@@ -16,7 +16,7 @@ import InstancePlayerList from './InstancePlayerList';
 
 import { Table, TableColumn, TableRow } from 'components/Table';
 import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
-import { ButtonMenuProps } from 'components/ButtonMenu';
+import { ButtonMenuConfig } from 'components/ButtonMenu';
 
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
@@ -121,7 +121,8 @@ const InstanceOverview = () => {
     { id: 30, make: 'Minox', model: '35 EL', lens: '35mm f/2.8', format: '35mm', year: 1974 },
   ];
 
-  const menuItems1: ButtonMenuProps = {
+  const menuItems1: ButtonMenuConfig = {
+    tableRows: rowsAnalog,
     menuItems: [
       {
         label: 'Edit in file viewer',
@@ -129,7 +130,7 @@ const InstanceOverview = () => {
         variant: 'text',
         intention: 'info',
         disabled: false,
-        onClick: () => console.log('Button 1 clicked'),
+        onClick: (row: TableRow) => console.log(`Edit on ${row.id}: ${row.make} ${row.model}`),
       },
       {
         label: 'another one',
@@ -137,7 +138,7 @@ const InstanceOverview = () => {
         variant: 'text',
         intention: 'info',
         disabled: false,
-        onClick: () => console.log('Button 1 clicked'),
+        onClick: (row: TableRow) => console.log(`Another on ${row.id}: ${row.make} ${row.model}`),
       },
       {
         label: 'Obliterate',
@@ -145,10 +146,11 @@ const InstanceOverview = () => {
         variant: 'text',
         intention: 'danger',
         disabled: false,
-        onClick: () => console.log('Button 2 clicked'),
+        onClick: (row: TableRow) => console.log(`Obliterate on ${row.id}: ${row.make} ${row.model}`),
       },
-    ]
+    ],
   };
+  
 
   return (
     <>
@@ -198,8 +200,8 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
-      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' />
-      <Table rows={rowsAnalog} columns={columnsAnalog} alignment='left' />
+      {/* <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' /> */}
+      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='left' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -199,7 +199,7 @@ const InstanceOverview = () => {
       </div>
       <InstancePerformanceCard />
       <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' />
-      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='even' />
+      <Table rows={rowsAnalog} columns={columnsAnalog} alignment='left' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -14,6 +14,10 @@ import { useGlobalSettings } from 'data/GlobalSettings';
 import { useDocumentTitle } from 'usehooks-ts';
 import InstancePlayerList from './InstancePlayerList';
 
+import { Table, TableColumn, TableRow } from 'components/Table';
+import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
+import { ButtonMenuProps } from 'components/ButtonMenu';
+
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
   const { core } = useContext(LodestoneContext);
@@ -64,6 +68,88 @@ const InstanceOverview = () => {
     }));
   };
 
+  const columnsBasic: TableColumn[] = [
+    { field: 'name', headerName: 'NAME' },
+    { field: 'age', headerName: 'AGE' },
+    { field: 'city', headerName: 'CITY' },
+  ];
+
+  const rowsBasic: TableRow[] = [
+    { id: 1, name: 'John', age: 30, city: 'New York' },
+    { id: 2, name: 'Jane', age: 25, city: 'Los Angeles' },
+    { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
+  ];
+
+  const columnsAnalog: TableColumn[] = [
+    { field: 'make', headerName: 'MAKE' },
+    { field: 'model', headerName: 'MODEL' },
+    { field: 'lens', headerName: 'LENS' },
+    { field: 'format', headerName: 'FORMAT' },
+    { field: 'year', headerName: 'YEAR' },
+  ];
+  
+  const rowsAnalog: TableRow[] = [
+    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
+    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
+    { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
+    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
+    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
+    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
+    { id: 7, make: 'Fuji', model: 'GW690III', lens: '90mm f/3.5', format: '120', year: 1980 },
+    { id: 8, make: 'Minolta', model: 'X-700', lens: '50mm f/1.7', format: '35mm', year: 1981 },
+    { id: 9, make: 'Rollei', model: '35T', lens: '40mm f/3.5', format: '35mm', year: 1960 },
+    { id: 10, make: 'Kodak', model: 'Retina IIc', lens: '50mm f/2.8', format: '35mm', year: 1954 },
+    { id: 11, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
+    { id: 12, make: 'Voigtlander', model: 'Bessa R3A', lens: '40mm f/1.4', format: '35mm', year: 2004 },
+    { id: 13, make: 'Zenza Bronica', model: 'SQ-Ai', lens: '80mm f/2.8', format: '120', year: 1982 },
+    { id: 14, make: 'Konica', model: 'Hexar AF', lens: '35mm f/2.0', format: '35mm', year: 1993 },
+    { id: 15, make: 'Zeiss Ikon', model: 'Contessa S310', lens: '45mm f/2.8', format: '35mm', year: 1957 },
+    { id: 16, make: 'Fujifilm', model: 'Instax Mini 9', lens: '60mm f/12.7', format: 'Instant', year: 2017 },
+    { id: 17, make: 'Polaroid', model: 'SX-70', lens: '116mm f/8', format: 'Polaroid', year: 1972 },
+    { id: 18, make: 'Fujifilm', model: 'Instax Mini 90', lens: '60mm f/12.7', format: 'Instant', year: 2013 },
+    { id: 19, make: 'Yashica', model: 'Mat-124G', lens: '80mm f/3.5', format: '120', year: 1970 },
+    { id: 20, make: 'Holga', model: '120N', lens: '60mm f/8', format: '120', year: 1982 },
+    { id: 21, make: 'Kodak', model: 'Brownie Hawkeye', lens: '75mm f/14.5', format: '620', year: 1949 },
+    { id: 22, make: 'Rollei', model: '35', lens: '40mm f/3.5', format: '35mm', year: 1966 },
+    { id: 23, make: 'Agfa', model: 'Clack', lens: '95mm f/11', format: '120', year: 1954 },
+    { id: 24, make: 'Lomography', model: 'Diana F+', lens: '75mm f/8', format: '120', year: 2007 },
+    { id: 25, make: 'Pentax', model: '645', lens: '75mm f/2.8', format: '120', year: 1984 },
+    { id: 26, make: 'Nimslo', model: 'Nimslo 3D', lens: '30mm f/5.6', format: '35mm', year: 1980 },
+    { id: 27, make: 'Voigtlander', model: 'Bessa R2A', lens: '50mm f/1.5', format: '35mm', year: 2004 },
+    { id: 28, make: 'Fujifilm', model: 'GFX 50S', lens: '63mm f/2.8', format: 'Medium Format', year: 2017 },
+    { id: 29, make: 'Bronica', model: 'SQ-A', lens: '80mm f/2.8', format: 'Medium Format', year: 1980 },
+    { id: 30, make: 'Minox', model: '35 EL', lens: '35mm f/2.8', format: '35mm', year: 1974 },
+  ];
+
+  const menuItems1: ButtonMenuProps = {
+    menuItems: [
+      {
+        label: 'Edit in file viewer',
+        icon: faEdit,
+        variant: 'text',
+        intention: 'info',
+        disabled: false,
+        onClick: () => console.log('Button 1 clicked'),
+      },
+      {
+        label: 'another one',
+        icon: faSkull,
+        variant: 'text',
+        intention: 'info',
+        disabled: false,
+        onClick: () => console.log('Button 1 clicked'),
+      },
+      {
+        label: 'Obliterate',
+        icon: faTrashCan,
+        variant: 'text',
+        intention: 'danger',
+        disabled: false,
+        onClick: () => console.log('Button 2 clicked'),
+      },
+    ]
+  };
+
   return (
     <>
       <div
@@ -112,6 +198,8 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
+      <Table rows={rowsBasic} columns={columnsBasic} menuOptions={menuItems1} alignment='even' />
+      <Table rows={rowsAnalog} columns={columnsAnalog} menuOptions={menuItems1} alignment='even' />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -16,7 +16,7 @@ import InstancePlayerList from './InstancePlayerList';
 
 import { Table } from 'components/Table';
 
-import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
 import { MenuItemProps } from 'components/ButtonMenu';
 
 export interface TableColumn {
@@ -114,8 +114,9 @@ const InstanceOverview = () => {
     { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
     { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
     { id: 3, make: 'Pentax', model: 'K1000', lens: '50mm f/2.0', format: '35mm', year: 1976 },
-    { id: 1, make: 'Nikon', model: 'FM2', lens: '50mm f/1.8', format: '35mm', year: 1982 },
-    { id: 2, make: 'Canon', model: 'AE-1', lens: '50mm f/1.4', format: '35mm', year: 1976 },
+    { id: 4, make: 'Mamiya', model: 'RB67', lens: '127mm f/3.8', format: '120', year: 1970 },
+    { id: 5, make: 'Hasselblad', model: '500CM', lens: '80mm f/2.8', format: '120', year: 1957 },
+    { id: 6, make: 'Leica', model: 'M6', lens: '35mm f/2.0', format: '35mm', year: 1984 },
   ];
   
   const rowsAnalog2: TableRow[] = [
@@ -133,15 +134,23 @@ const InstanceOverview = () => {
     menuItems: [
       {
         label: 'Edit in file viewer',
-        icon: faEllipsisVertical,
+        icon: faEdit,
         variant: 'text',
         intention: 'info',
         disabled: false,
         onClick: () => console.log('Button 1 clicked'),
       },
       {
-        label: 'Delete',
-        icon: faEllipsisVertical,
+        label: 'why the fuck is this justified start',
+        icon: faSkull,
+        variant: 'text',
+        intention: 'info',
+        disabled: false,
+        onClick: () => console.log('Button 1 clicked'),
+      },
+      {
+        label: 'Obliterate',
+        icon: faTrashCan,
         variant: 'text',
         intention: 'danger',
         disabled: false,

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -14,20 +14,9 @@ import { useGlobalSettings } from 'data/GlobalSettings';
 import { useDocumentTitle } from 'usehooks-ts';
 import InstancePlayerList from './InstancePlayerList';
 
-import { Table } from 'components/Table';
-
+import { Table, TableColumn, TableRow } from 'components/Table';
 import { faTrashCan, faEdit, faSkull } from '@fortawesome/free-solid-svg-icons';
 import { MenuItemProps } from 'components/ButtonMenu';
-
-export interface TableColumn {
-  field: string;
-  headerName: string;
-  className?: string;
-}
-
-export interface TableRow {
-  [key: string]: React.ReactNode;
-} 
 
 interface FilmCameraRow {
   id: number;

--- a/src/components/Instance/InstanceOverview.tsx
+++ b/src/components/Instance/InstanceOverview.tsx
@@ -14,6 +14,18 @@ import { useGlobalSettings } from 'data/GlobalSettings';
 import { useDocumentTitle } from 'usehooks-ts';
 import InstancePlayerList from './InstancePlayerList';
 
+import { Table } from 'components/Table';
+
+export interface TableColumn {
+  field: string;
+  headerName: string;
+  className?: string;
+}
+
+export interface TableRow {
+  [key: string]: React.ReactNode;
+} 
+
 const InstanceOverview = () => {
   useDocumentTitle('Dashboard - Lodestone');
   const { core } = useContext(LodestoneContext);
@@ -64,6 +76,18 @@ const InstanceOverview = () => {
     }));
   };
 
+  const columns: TableColumn[] = [
+    { field: 'name', headerName: 'Name' },
+    { field: 'age', headerName: 'Age' },
+    { field: 'city', headerName: 'City', className: 'column-city' },
+  ];
+
+  const rows: TableRow[] = [
+    { id: 1, name: 'John', age: 30, city: 'New York' },
+    { id: 2, name: 'Jane', age: 25, city: 'Los Angeles' },
+    { id: 3, name: 'Bob', age: 45, city: 'Chicago' },
+  ];
+
   return (
     <>
       <div
@@ -112,6 +136,7 @@ const InstanceOverview = () => {
         </div>
       </div>
       <InstancePerformanceCard />
+      <Table rows={rows} columns={columns} />
       <InstancePlayerList />
     </>
   );

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from "clsx";
 
-import Menu from './ButtonMenu';
+import ButtonMenu from './ButtonMenu';
 import { MenuItemProps } from './ButtonMenu';
 
 export interface TableColumn {
@@ -27,7 +27,7 @@ export function Table({rows, columns, menuOptions, className}: TableProps) {
   const modifiedColumns = menuOptions ? [...columns, {
     field: 'menu',
     headerName: '',
-    element: () => <Menu menuItems={menuOptions.menuItems} />,
+    element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
     className: 'text-end',
   }] : columns;
   

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import {cn} from "../utils/util";
 import clsx from "clsx";
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import Menu from './ButtonMenu';
+import { MenuItemProps } from './ButtonMenu';
 
 export interface TableColumn {
   field: string;
@@ -15,15 +14,18 @@ export interface TableRow {
   [key: string]: React.ReactNode;
 }
 
-interface CardProps {
+interface TableProps {
   rows: TableRow[];
   columns: TableColumn[];
+  menuOptions?: MenuItemProps;
   className?: string;
 }
 
-export function Table({rows, columns, className}: CardProps) {
+export function Table({rows, columns, menuOptions, className}: TableProps) {
+  
+
   return (
-    <table className={cn("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
+    <table className={clsx("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
       <tr>
         {columns.map((column, cIndex) => (
@@ -36,26 +38,29 @@ export function Table({rows, columns, className}: CardProps) {
       </tr>
       </thead>
       <tbody>
-      {rows.map((row, index) => {
-        return (
-          <tr
-            className={clsx("h-10 border-b border-b-fade-700", index % 2 === 1 && "bg-gray-850")}
-            key={index}
-          >
-            {columns.map((column, cIndex) => (
-              <td key={cIndex}
-              className={cn("px-3 text-left text-white/50", column.className)}>
-                {row[column.field]}
-              </td>
-            ))}
-            <td>
-              <button>
-                <FontAwesomeIcon icon={faEllipsisVertical}/>
-              </button>
+        {rows.map((row, index) => {
+          return (
+            <tr
+              className={clsx("h-12 border-b border-b-fade-700", index % 2 === 1 && "bg-gray-850")}
+              key={index}
+            >
+              {columns.map((column, cIndex) => (
+                <td key={cIndex}
+                className={clsx("px-3 text-left text-white/50", column.className)}>
+                  {row[column.field]}
+                </td>
+              ))}
+              <td>
+              {menuOptions ? (
+                <Menu
+                  menuItems={menuOptions.menuItems}
+                />
+              ) : null}
             </td>
-          </tr>
-        )
-      })}
+            </tr>
+          )
+        })}
+        
       </tbody>
     </table>
   );

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -18,11 +18,13 @@ export interface TableRow {
 interface TableProps {
   rows: TableRow[];
   columns: TableColumn[];
+  alignment?: 'auto' | 'left' | 'right';
   menuOptions?: ButtonMenuProps;
   className?: string;
 }
 
-export function Table({rows, columns, menuOptions, className}: TableProps) {
+export function Table({rows, columns, alignment = 'auto', menuOptions, className}: TableProps) {
+  
   // If menuOptions is truthy, add an extra column for the menu buttons
   const modifiedColumns = menuOptions ? [...columns, {
     field: 'menu',
@@ -32,30 +34,29 @@ export function Table({rows, columns, menuOptions, className}: TableProps) {
   }] : columns;
 
   return (
-    <table className={clsx("table-fixed whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
+    <table className={clsx("w-full table-fixed bg-gray-875 text-left tracking-medium", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
-      <tr>
-        {modifiedColumns.map((column, cIndex) => (
+        <tr>
+          {modifiedColumns.map((column, cIndex) => (
             <th
               key={cIndex}
-              className="sticky top-0 bg-gray-875 px-4 text-medium font-bold"
+              className="sticky top-0 bg-gray-875 px-4 py-2 text-medium font-bold"
             >
               {column.headerName}
             </th>
-          )
-        )}
-      </tr>
+          ))}
+        </tr>
       </thead>
       <tbody>
         {rows.map((row, indexRow) => (
           <tr
             key={indexRow}
-            className={clsx("h-12 border-b border-b-fade-700", indexRow % 2 === 1 && "bg-gray-850")}
+            className={clsx("h-full border-b border-b-fade-700", indexRow % 2 === 1 && "bg-gray-850")}
           >
             {modifiedColumns.map((column, indexColumn) => (
               <td
                 key={indexColumn}
-                className={clsx("px-4 text-left text-white/50", column.className)}
+                className={clsx("p-4 text-left text-white/50", column.className)}
               >
                 {column.element ? column.element(row) : row[column.field]}
               </td>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,58 +2,61 @@ import * as React from 'react';
 import {cn} from "../utils/util";
 import clsx from "clsx";
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 
 export interface TableColumn {
-    field: string;
-    headerName: string;
-    className?: string;
+  field: string;
+  headerName: string;
+  className?: string;
 }
 
 export interface TableRow {
-    [key: string]: React.ReactNode;
+  [key: string]: React.ReactNode;
 }
 
 interface CardProps {
-    rows: TableRow[];
-    columns: TableColumn[];
-    className?: string;
+  rows: TableRow[];
+  columns: TableColumn[];
+  className?: string;
 }
 
 export function Table({rows, columns, className}: CardProps) {
-    return (
-        <table className={cn("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
-            <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
-            <tr>
-                {columns.map((column, cIndex) => (
-                        <th key={cIndex}
-                            className="sticky top-0 bg-gray-875 px-3 text-small font-bold">
-                            {column.headerName}
-                        </th>
-                    )
-                )}
-            </tr>
-            </thead>
-            <tbody>
-            {rows.map((row, index) => {
-
-                return (
-                    <tr
-                        className={clsx("h-10 border-b border-b-fade-700", index % 2 === 1 && "bg-gray-850")}
-                        key={index}>
-                        {columns.map((column, cIndex) => (
-                                <td key={cIndex}
-                                    className={cn("px-3 text-left text-white/50", column.className)}>
-                                    {row[column.field]}
-                                </td>
-                            )
-                        )}
-                    </tr>
-                )
-            })}
-
-
-            </tbody>
-
-        </table>
-    );
+  return (
+    <table className={cn("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
+      <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
+      <tr>
+        {columns.map((column, cIndex) => (
+            <th key={cIndex}
+              className="sticky top-0 bg-gray-875 px-3 text-small font-bold">
+              {column.headerName}
+            </th>
+          )
+        )}
+      </tr>
+      </thead>
+      <tbody>
+      {rows.map((row, index) => {
+        return (
+          <tr
+            className={clsx("h-10 border-b border-b-fade-700", index % 2 === 1 && "bg-gray-850")}
+            key={index}
+          >
+            {columns.map((column, cIndex) => (
+              <td key={cIndex}
+              className={cn("px-3 text-left text-white/50", column.className)}>
+                {row[column.field]}
+              </td>
+            ))}
+            <td>
+              <button>
+                <FontAwesomeIcon icon={faEllipsisVertical}/>
+              </button>
+            </td>
+          </tr>
+        )
+      })}
+      </tbody>
+    </table>
+  );
 }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -26,13 +26,19 @@ interface TableProps {
 export function Table({rows, columns, alignment = 'even', menuOptions, className}: TableProps) {
   
   // If menuOptions is truthy, add an extra column for the menu buttons
-  // If alignment === 'left', add 'w-full' to className
-  const modifiedColumns = menuOptions ? [...columns, {
-    field: 'menu',
-    headerName: '',
-    element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
-    className: `text-end ${alignment === 'left' ? 'w-full' : ''}`,
-  }] : columns;
+  // If alignment === 'left', add 'w-full' to className of last column
+  const modifiedColumns = menuOptions
+    ? [...columns, {
+        field: 'menu',
+        headerName: '',
+        element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
+        className: `text-end ${alignment === 'left' ? 'w-full' : ''}`,
+      }]
+    : alignment == 'left'
+    ? columns.map((column, index, array) =>
+      index === array.length - 1 ? { ...column, className: 'w-full' } : column
+      )
+    : columns;
 
   // Code currently uses arbitrary values for min and max width when alignment is set to left
   return (

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -18,29 +18,31 @@ export interface TableRow {
 interface TableProps {
   rows: TableRow[];
   columns: TableColumn[];
-  alignment?: 'auto' | 'left' | 'right';
+  alignment?: 'even' | 'left';
   menuOptions?: ButtonMenuProps;
   className?: string;
 }
 
-export function Table({rows, columns, alignment = 'auto', menuOptions, className}: TableProps) {
+export function Table({rows, columns, alignment = 'even', menuOptions, className}: TableProps) {
   
   // If menuOptions is truthy, add an extra column for the menu buttons
+  // If alignment === 'left', add 'w-full' to className
   const modifiedColumns = menuOptions ? [...columns, {
     field: 'menu',
     headerName: '',
     element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
-    className: 'text-end',
+    className: `text-end ${alignment === 'left' ? 'w-full' : ''}`,
   }] : columns;
 
+  // Code currently uses arbitrary values for min and max width when alignment is set to left
   return (
-    <table className={clsx("w-full table-fixed bg-gray-875 text-left tracking-medium", className)}>
+    <table className={clsx("w-full bg-gray-875 text-left tracking-medium", alignment === 'even' ? "table-fixed" : "table-auto", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
         <tr>
           {modifiedColumns.map((column, cIndex) => (
             <th
               key={cIndex}
-              className="sticky top-0 bg-gray-875 px-4 py-2 text-medium font-bold"
+              className={clsx("sticky top-0 z-20 bg-gray-875 px-4 py-2 text-medium font-bold", alignment === 'left' && "min-w-[8rem] max-w-[12rem]")}
             >
               {column.headerName}
             </th>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,13 +1,12 @@
-import * as React from 'react';
-import clsx from "clsx";
-
 import ButtonMenu from './ButtonMenu';
-import { ButtonMenuProps } from './ButtonMenu';
+import { ButtonMenuConfig } from './ButtonMenu';
+
+import clsx from "clsx";
 
 export interface TableColumn {
   field: string;
   headerName: string;
-  element?: (row: TableRow) => React.ReactElement;
+  element?: (rows: TableRow[], rowIndex: number) => React.ReactElement;
   className?: string;
 }
 
@@ -19,19 +18,23 @@ interface TableProps {
   rows: TableRow[];
   columns: TableColumn[];
   alignment?: 'even' | 'left';
-  menuOptions?: ButtonMenuProps;
+  menuOptions?: ButtonMenuConfig;
   className?: string;
 }
 
 export function Table({rows, columns, alignment = 'even', menuOptions, className}: TableProps) {
   
   // If menuOptions is truthy, add an extra column for the menu buttons
+  // Add a unique index for each ButtonMenu created to control respective rows
   // If alignment === 'left', add 'w-full' to className of last column
   const modifiedColumns = menuOptions
+    // ? [...columns, {
     ? [...columns, {
         field: 'menu',
         headerName: '',
-        element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
+        element: (rows: TableRow[], rowIndex: number) => (
+          <ButtonMenu tableRows={rows} rowIndex={rowIndex} menuItems={menuOptions.menuItems} />
+        ),
         className: `text-end ${alignment === 'left' ? 'w-full' : ''}`,
       }]
     : alignment == 'left'
@@ -42,13 +45,13 @@ export function Table({rows, columns, alignment = 'even', menuOptions, className
 
   // Code currently uses arbitrary values for min and max width when alignment is set to left
   return (
-    <table className={clsx("w-full bg-gray-875 text-left tracking-medium", alignment === 'even' ? "table-fixed" : "table-auto", className)}>
+    <table className={clsx("z-10 w-full bg-gray-875 text-left tracking-medium", alignment === 'even' ? "table-fixed" : "table-auto", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
         <tr>
           {modifiedColumns.map((column, cIndex) => (
             <th
               key={cIndex}
-              className={clsx("sticky top-0 z-20 bg-gray-875 px-4 py-2 text-medium font-bold", alignment === 'left' && "min-w-[8rem] max-w-[12rem]")}
+              className={clsx("sticky top-0 z-30 bg-gray-875 px-4 py-2 text-medium font-bold", alignment === 'left' && "min-w-[8rem] max-w-[12rem]")}
             >
               {column.headerName}
             </th>
@@ -66,7 +69,7 @@ export function Table({rows, columns, alignment = 'even', menuOptions, className
                 key={indexColumn}
                 className={clsx("p-4 text-left text-white/50", column.className)}
               >
-                {column.element ? column.element(row) : row[column.field]}
+                {column.element ? column.element(rows, indexRow) : row[column.field]}
               </td>
             ))}
           </tr>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -7,6 +7,7 @@ import { MenuItemProps } from './ButtonMenu';
 export interface TableColumn {
   field: string;
   headerName: string;
+  element?: (row: TableRow) => React.ReactElement;
   className?: string;
 }
 
@@ -22,15 +23,23 @@ interface TableProps {
 }
 
 export function Table({rows, columns, menuOptions, className}: TableProps) {
+  // If menuOptions is truthy, add an extra column for the menu buttons
+  const modifiedColumns = menuOptions ? [...columns, {
+    field: 'menu',
+    headerName: '',
+    element: () => <Menu menuItems={menuOptions.menuItems} />,
+    className: 'text-end',
+  }] : columns;
   
-
   return (
     <table className={clsx("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
       <tr>
-        {columns.map((column, cIndex) => (
-            <th key={cIndex}
-              className="sticky top-0 bg-gray-875 px-3 text-small font-bold">
+        {modifiedColumns.map((column, cIndex) => (
+            <th
+              key={cIndex}
+              className="sticky top-0 bg-gray-875 px-4 text-medium font-bold"
+            >
               {column.headerName}
             </th>
           )
@@ -38,29 +47,23 @@ export function Table({rows, columns, menuOptions, className}: TableProps) {
       </tr>
       </thead>
       <tbody>
-        {rows.map((row, index) => {
+        {rows.map((row, indexRow) => {
           return (
             <tr
-              className={clsx("h-12 border-b border-b-fade-700", index % 2 === 1 && "bg-gray-850")}
-              key={index}
+              key={indexRow}
+              className={clsx("h-12 border-b border-b-fade-700", indexRow % 2 === 1 && "bg-gray-850")}
             >
-              {columns.map((column, cIndex) => (
-                <td key={cIndex}
-                className={clsx("px-3 text-left text-white/50", column.className)}>
-                  {row[column.field]}
+              {modifiedColumns.map((column, indexColumn) => (
+                <td
+                  key={indexColumn}
+                  className={clsx("px-4 text-left text-white/50", column.className)}
+                >
+                  {column.element ? column.element(row) : row[column.field]}
                 </td>
               ))}
-              <td>
-              {menuOptions ? (
-                <Menu
-                  menuItems={menuOptions.menuItems}
-                />
-              ) : null}
-            </td>
             </tr>
           )
         })}
-        
       </tbody>
     </table>
   );

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -28,7 +28,6 @@ export function Table({rows, columns, alignment = 'even', menuOptions, className
   // Add a unique index for each ButtonMenu created to control respective rows
   // If alignment === 'left', add 'w-full' to className of last column
   const modifiedColumns = menuOptions
-    // ? [...columns, {
     ? [...columns, {
         field: 'menu',
         headerName: '',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from "clsx";
 
 import ButtonMenu from './ButtonMenu';
-import { MenuItemProps } from './ButtonMenu';
+import { ButtonMenuProps } from './ButtonMenu';
 
 export interface TableColumn {
   field: string;
@@ -18,7 +18,7 @@ export interface TableRow {
 interface TableProps {
   rows: TableRow[];
   columns: TableColumn[];
-  menuOptions?: MenuItemProps;
+  menuOptions?: ButtonMenuProps;
   className?: string;
 }
 
@@ -30,9 +30,9 @@ export function Table({rows, columns, menuOptions, className}: TableProps) {
     element: () => <ButtonMenu menuItems={menuOptions.menuItems} />,
     className: 'text-end',
   }] : columns;
-  
+
   return (
-    <table className={clsx("table-auto whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
+    <table className={clsx("table-fixed whitespace-nowrap bg-gray-875 text-left tracking-medium", className)}>
       <thead className="h-6 border-b border-b-fade-700 bg-gray-875">
       <tr>
         {modifiedColumns.map((column, cIndex) => (
@@ -47,23 +47,21 @@ export function Table({rows, columns, menuOptions, className}: TableProps) {
       </tr>
       </thead>
       <tbody>
-        {rows.map((row, indexRow) => {
-          return (
-            <tr
-              key={indexRow}
-              className={clsx("h-12 border-b border-b-fade-700", indexRow % 2 === 1 && "bg-gray-850")}
-            >
-              {modifiedColumns.map((column, indexColumn) => (
-                <td
-                  key={indexColumn}
-                  className={clsx("px-4 text-left text-white/50", column.className)}
-                >
-                  {column.element ? column.element(row) : row[column.field]}
-                </td>
-              ))}
-            </tr>
-          )
-        })}
+        {rows.map((row, indexRow) => (
+          <tr
+            key={indexRow}
+            className={clsx("h-12 border-b border-b-fade-700", indexRow % 2 === 1 && "bg-gray-850")}
+          >
+            {modifiedColumns.map((column, indexColumn) => (
+              <td
+                key={indexColumn}
+                className={clsx("px-4 text-left text-white/50", column.className)}
+              >
+                {column.element ? column.element(row) : row[column.field]}
+              </td>
+            ))}
+          </tr>
+        ))}
       </tbody>
     </table>
   );


### PR DESCRIPTION
# Description

https://github.com/Lodestone-Team/lodestone/issues/208

Modified the table to take in additional the additional prop `alignment` to either align the table left or evenly space out all column. The option to space it using `table-auto` has been removed since it can have some unintended behavior. Also added a new component `buttonMenu` that allows developer to customize their buttons on the table.

For left align, each cell has a minimum width of `8rem` and a max of `12rem`. The button column then fills the rest of the space. For even alignment, each cell has the same width, including the menu button column. The table component defaults to a even align if the `alignment` prop is not passed in.

![image](https://user-images.githubusercontent.com/43940223/229331267-8fb616f0-b621-4e11-928a-7199907d04cb.png)

The first table is using `alignment = 'even'` and the second table is using `alignment = 'left'`