### PR TITLE
Add support for IPv6

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -625,7 +625,7 @@ pub async fn run(
                     debug!("Port {port} is already in use, trying next port");
                     port += 1;
                 }
-                let addr = SocketAddr::from(([0, 0, 0, 0], port));
+                let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
                 let axum_server_handle = axum_server::Handle::new();
                 tokio::spawn({
                     let axum_server_handle = axum_server_handle.clone();


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #321 

Core listens IPv6 by default. According to [this answer](https://users.rust-lang.org/t/how-to-listen-on-all-interfaces-with-tcplistener-solved/12269/3), this would not affect IPv4 connectivity. 

## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*