### PR TITLE
290 desktop client should not force user to setup a local core

### DIFF
--- a/dashboard/src/pages/login/CoreSelectExisting.tsx
+++ b/dashboard/src/pages/login/CoreSelectExisting.tsx
@@ -11,12 +11,14 @@ import {
   faClone,
   faDownload,
   faPlus,
+  faScrewdriverWrench
 } from '@fortawesome/free-solid-svg-icons';
 import SelectField from 'components/Atoms/Form/SelectField';
 import { BrowserLocationContext } from 'data/BrowserLocationContext';
 import { CoreInfo } from 'data/SystemInfo';
 import { useDocumentTitle } from 'usehooks-ts';
 import WarningAlert from 'components/Atoms/WarningAlert';
+import { tauri } from 'utils/tauriUtil';
 type SelectCoreValue = {
   core: CoreConnectionInfo;
 };
@@ -133,6 +135,33 @@ const CoreSelectExisting = () => {
                   );
                 }}
               />
+              {
+                tauri && <Button
+                type="button"
+                iconRight={faScrewdriverWrench}
+                label="Setup Core Locally"
+                onClick={() => {
+                  // extremely sus setup that should probably be fixed by directly calling the onSubmit logic
+                  // rather than duplication
+                  const core = coreList[0]
+                  axios
+                    .get<CoreInfo>(`/info`, {
+                      baseURL: `${core.protocol}://${core.address}:${core.port}/api/${core.apiVersion}`,
+                    })
+                    .then((res) => {
+                      if (res.status !== 200)
+                        throw new Error('Invalid response, setup may be invalid');
+                      setCore(core);
+                      if (res.data.is_setup === false) {
+                        setPathname('/login/core/first_setup');
+                      } else {
+                        setPathname('/login/user/select');
+                      }
+                  })
+                }}
+              />
+              }
+              
               <Button
                 type="submit"
                 intention="primary"

--- a/dashboard/src/pages/login/FirstTime.tsx
+++ b/dashboard/src/pages/login/FirstTime.tsx
@@ -95,7 +95,7 @@ const FirstTime = () => {
             <Button
               label="Connect to existing Core"
               onClick={() => setPathname('/login/core/new')}
-              intention="primary"
+              intention="info"
               size="large"
               className="whitespace-nowrap"
             />
@@ -109,13 +109,26 @@ const FirstTime = () => {
             className="whitespace-nowrap"
           />
         ) : (
-          <Button
-            label="Setup Lodestone Core"
-            onClick={() => setPathname('/login/core/first_setup')}
-            intention="primary"
-            size="large"
-            className="whitespace-nowrap"
-          />
+          <>
+            <Button
+              label="Setup core locally"
+              onClick={() => setPathname('/login/core/first_setup')}
+              intention="primary"
+              size="large"
+              className="whitespace-nowrap"
+            />
+            <Button
+              label="Connect to existing core"
+              onClick = {() => {
+                setPathname('/login/core/select')
+              }}
+              intention = 'primary'
+              size = "large"
+              className="whitespace-nowrap"
+            />
+          
+          </>
+          
         )}
       </div>
     </div>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added way for users to skip local core setup in initial page load in Tauri:
![image](https://github.com/Lodestone-Team/lodestone/assets/88288337/24ced799-c45a-4883-b8e5-0b2388e12055)

Added extra button in core select page in Tauri for local setup later on - this works by selecting the first option that shows up in Tauri, which might not work in all cases.
![image](https://github.com/Lodestone-Team/lodestone/assets/88288337/719be0db-3833-487f-890d-44ed6e2d9c25)


## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*