### PR TITLE
Add support for beta prerelease docker builds in actions

### DIFF
--- a/.github/workflows/core-release-docker.yml
+++ b/.github/workflows/core-release-docker.yml
@@ -2,7 +2,7 @@ name: Core - Release Docker
 
 on:
   release:
-    types: [released]
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -51,6 +51,12 @@ jobs:
         id: substring
         run: echo "version=${VERSION:1}" >> $GITHUB_OUTPUT
 
+      - name: set docker version label
+        env:
+          LABEL: ${{ !github.event.release.prerelease && 'latest-stable' || 'latest-beta' }}
+        id: release_type
+        run: echo "label=${LABEL}" >> $GITHUB_OUTPUT
+
       - name: build and push
         uses: docker/build-push-action@v3
         with:
@@ -60,4 +66,7 @@ jobs:
           build-args: |
             lodestone_version=${{ steps.release_asset.outputs.version }}
           push: true
-          tags: ${{ steps.string_tag.outputs.lowercase }}:latest,${{ steps.string_tag.outputs.lowercase }}:${{ steps.substring.outputs.version }}
+          tags: |
+            ${{ steps.string_tag.outputs.lowercase }}:latest
+            ${{ steps.string_tag.outputs.lowercase }}:${{ steps.release_type.outputs.label }}
+            ${{ steps.string_tag.outputs.lowercase }}:${{ steps.substring.outputs.version }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Makes docker build trigger on publish (release + prerelease) and tags the docker build with an additional `latest-stable` or `latest-beta` as well.

## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*