### PR TITLE
Fix notifications text wrap

### DIFF
--- a/dashboard/src/components/Atoms/NotificationCard.tsx
+++ b/dashboard/src/components/Atoms/NotificationCard.tsx
@@ -51,7 +51,7 @@ export default function NotificationCard({
       >
         <LoadingStatusIcon level={level} state={state} />
         <div className="flex flex-col items-start">
-          <p className="w-full text-medium font-bold tracking-medium">
+          <p className="w-full text-medium font-bold tracking-medium break-all">
             {title}
           </p>
           <p className="w-full text-medium font-medium tracking-medium">


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed the bug where long words (without a space) were not being wrapped on multiple lines.
Now they wrap like this:
![image](https://github.com/Lodestone-Team/lodestone/assets/49595640/7ed183fe-5ee9-4e6d-9124-573aedd353c6)


close #308 


## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*