### PR TITLE
Add an endpoint to clear an instance's console buffer

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -133,6 +133,10 @@ impl AppState {
             });
         }
     }
+
+    pub async fn clear_console_buffer(&self, uuid: &InstanceUuid) {
+        self.console_out_buffer.lock().await.remove(uuid);
+    }
 }
 
 async fn restore_instances(


### PR DESCRIPTION
Fixes #299

Add an endpoint to clear an instance's console buffer by clearing the circular buffer within the global app state buffer.

* **core/src/lib.rs**
  - Add a method `clear_console_buffer` to the `AppState` struct to clear the console buffer for a specific instance.

* **core/src/handlers/events.rs**
  - Add a new function `clear_console_buffer` to handle the request to clear the console buffer.
  - Add a new route `/instance/:uuid/console/clear` to handle the request to clear the console buffer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Lodestone-Team/lodestone/issues/299?shareId=be421de6-6bdd-458b-8611-d5818dbaa4e6).