### PR TITLE
Update lib.rs to add dualstack support (windows only atm)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -707,7 +707,11 @@ pub async fn run(
                     debug!("Port {port} is already in use, trying next port");
                     port += 1;
                 }
-                let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
+                let addr = if cfg!(windows) {
+                    SocketAddr::new(std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), port)
+                } else {
+                    SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), port)
+                };
                 let axum_server_handle = axum_server::Handle::new();
                 tokio::spawn({
                     let axum_server_handle = axum_server_handle.clone();


### PR DESCRIPTION
Added this change because the recent change to ipv6 broke my server entirely. This utilizes dual stack to translate ipv4 addresses to ipv6 on windows.

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->



## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*