### PR TITLE
Fix macro wiki link sending user to nonexistent wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A free, open source server hosting tool for Minecraft and other multiplayers gam
 - [x] Collaborative remote server and resource management
 - [x] Priority on safety and security
 - [x] User permission management
-- [x] *(New!)* Extensions via macro (read more [here](https://github.com/Lodestone-Team/lodestone/wiki/Macro-and-Task))
+- [x] *(New!)* Extensions via macro (read more [here](https://github.com/Lodestone-Team/lodestone/wiki/Intro-to-Macro-and-Task))
 - [x] *(New!)* Connect without port forward via playit.gg integration (read more [here](https://github.com/Lodestone-Team/lodestone/wiki/Playit.gg-Integration))
 - [ ] *(New!)* **Manage Docker containers** (WIP 🚧, read more [here](https://github.com/Lodestone-Team/lodestone/wiki/Docker-Instance))
 


### PR DESCRIPTION
Replaced the wiki url refering the user to the macro wiki page with one that actualy works

# Description
Fix macro wiki link sending user to nonexistent wiki page

The link to the macro wiki refered the user to a non existent page. Fixed it so it refers the user to the actual page
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->



## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*