### PR TITLE
Dashboard docker path routing

### DIFF
--- a/.github/workflows/dashboard-release-docker.yml
+++ b/.github/workflows/dashboard-release-docker.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           context: ./dashboard
           platforms: linux/amd64,linux/arm64
-          file: ./dashboard/Dockerfile
+          file: ./dashboard/docker/Dockerfile
           push: true
           tags: |
             ${{ steps.string_tag.outputs.lowercase }}:latest

--- a/dashboard/docker/Dockerfile
+++ b/dashboard/docker/Dockerfile
@@ -15,3 +15,6 @@ FROM nginx
 WORKDIR /usr/share/nginx/html
 
 COPY --from=build /app/out/ ./
+# Replace the default server configuration, but leave the overall nginx
+# configuration
+COPY ./docker/server.nginx.conf /etc/nginx/conf.d/default.conf

--- a/dashboard/docker/README.md
+++ b/dashboard/docker/README.md
@@ -1,0 +1,6 @@
+## Self Hosting with Docker
+Example:
+```shell
+docker run -d -p 3001:80 --name lodestone-dashboard ghcr.io/lodestone-team/lodestone_dashboard
+```
+And then the dashboard will be available at http://localhost:3001

--- a/dashboard/docker/server.nginx.conf
+++ b/dashboard/docker/server.nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
# Description

The current docker image does not support any path routing. If you go to any
path other than the root, it 404s.

For example, if you go to a page other than the index and then refresh, it will
404.

This adds basic routing to fall back to `index.html` if a file isn't found. This
is already properly handled by the built `index.html` such that an invalid path
will show a proper 404 page (rather than the nginx 404 page).

## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*
