### PR TITLE
Add Multi-Folder Backups

### DIFF
--- a/example-macros/auto-backup/index.ts
+++ b/example-macros/auto-backup/index.ts
@@ -60,8 +60,8 @@ while (true) {
 
   if (config.compressBackup) {
     try {
-      await eventStream.emitConsoleOut(`[Backup Macro] Compressing backup...`);
-      await compress(`${combinedBackupFolder}`, `${instancePath}/${config.backupFolderRelative}/${combinedBackupFolder}.zip`);
+      await eventStream.emitConsoleOut(`[Backup Macro] Compressing backup folder: ${combinedBackupFolder}...`);
+      await compress(`${combinedBackupFolder}/`, `${combinedBackupFolder}.zip`);
       await eventStream.emitConsoleOut(`[Backup Macro] Compression completed.`);
     } catch (e) {
       console.log(`[Backup Macro] Error compressing backup folder:`, e);


### PR DESCRIPTION
# Description

I added the ability to specify a list of folders to back up, as I wanted to back up the end and nether as well, and large servers may want to back up lobbies or assorted worlds. I also tried setting up compression using the zip module, but I am unsure of why it is not working, any pointers?.



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
